### PR TITLE
Rename "Paste text again" context menu item

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,7 +3,7 @@ function loripsum() {
 
   // Paste last used loripsum text.
   chrome.contextMenus.create({
-    'title': 'Paste text again',
+    'title': 'Use last configuration',
     'contexts': ['editable'],
     'parentId': main,
     'onclick': function () {


### PR DESCRIPTION
What do you think about using the string `Use last configuration` instead of the current one? When you click `Paste text again` it's not the same so the functionality behind that menu item is not true.
